### PR TITLE
Update settings configuration

### DIFF
--- a/core_api/settings.py
+++ b/core_api/settings.py
@@ -125,6 +125,7 @@ CORS_ALLOWED_ORIGINS = [
     os.getenv('CORS_ORIGIN_2', 'http://127.0.0.1:5173'),
     os.getenv('CORS_ORIGIN_3', 'http://localhost:3000'),
     os.getenv('CORS_ORIGIN_4', 'http://127.0.0.1:3000'),
+    os.getenv('CORS_ORIGIN_5', 'http://192.168.1.19:5173'),  # phone on Wi-Fi via Expo WebView
 ]
 
 CORS_ALLOW_CREDENTIALS = True


### PR DESCRIPTION
This pull request adds support for a new CORS origin to the API settings, allowing requests from a device on the local Wi-Fi network. This is useful for testing from a phone using Expo WebView.

- CORS configuration:
  * Added `http://192.168.1.19:5173` as an allowed CORS origin in `core_api/settings.py` to support access from a phone on the same Wi-Fi network via Expo WebView.