### PR TITLE
Enable regex-based CORS for private LAN origins in Vite

### DIFF
--- a/core_api/settings.py
+++ b/core_api/settings.py
@@ -125,7 +125,15 @@ CORS_ALLOWED_ORIGINS = [
     os.getenv('CORS_ORIGIN_2', 'http://127.0.0.1:5173'),
     os.getenv('CORS_ORIGIN_3', 'http://localhost:3000'),
     os.getenv('CORS_ORIGIN_4', 'http://127.0.0.1:3000'),
-    os.getenv('CORS_ORIGIN_5', 'http://192.168.1.19:5173'),  # phone on Wi-Fi via Expo WebView
+]
+
+# Matches the Vite dev server reached from any private LAN IP (phone on Wi-Fi via
+# Expo WebView), so this keeps working when the machine's IP changes or the app
+# runs from a different laptop/network, without hardcoding any specific address.
+CORS_ALLOWED_ORIGIN_REGEXES = [
+    r'^http://192\.168\.\d{1,3}\.\d{1,3}:5173$',
+    r'^http://10\.\d{1,3}\.\d{1,3}\.\d{1,3}:5173$',
+    r'^http://172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}:5173$',
 ]
 
 CORS_ALLOW_CREDENTIALS = True


### PR DESCRIPTION
This pull request improves the handling of CORS (Cross-Origin Resource Sharing) origins in the `core_api/settings.py` file. Instead of hardcoding a specific LAN IP for development, it introduces regular expressions to allow requests from any private LAN IP address, making local development and testing on different networks or machines more flexible.

CORS configuration improvements:

* Removed the hardcoded `CORS_ORIGIN_5` entry for a specific LAN IP and replaced it with `CORS_ALLOWED_ORIGIN_REGEXES`, which allows requests from any private LAN IP address on port 5173 (commonly used by the Vite dev server). This change supports development scenarios where the server's IP may change, such as using a phone on Wi-Fi or switching networks.